### PR TITLE
Add seed script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,27 @@ which can be stored in `localStorage` for authenticated requests.
 ### Chapters and Comments
 
 Authors can create chapters from a fiction page once logged in. Each chapter page shows the chapter text and a comment thread. Comments are posted to `/api/comments/:chapterId` and fetched from the same endpoint.
+
+### Sample Data
+
+You can populate a local PostgreSQL database with demo content using the seed
+script:
+
+```bash
+# create a database if needed
+createdb webnovel
+
+# configure environment variables
+cp backend/.env.example backend/.env
+```
+
+Edit `backend/.env` so `DATABASE_URL` points to your Postgres instance and set
+`JWT_SECRET` to any value. Then run:
+
+```bash
+cd backend
+npm run seed
+```
+
+This will recreate the tables and insert a few authors, fictions, chapters and
+comments for testing.

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest"
+    "test": "jest",
+    "seed": "node seed.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -1,0 +1,70 @@
+const bcrypt = require('bcrypt');
+const { sequelize } = require('./config/database');
+const User = require('./models/user');
+const Fiction = require('./models/fiction');
+const Chapter = require('./models/chapter');
+const Comment = require('./models/comment');
+
+async function run() {
+  await sequelize.sync({ force: true });
+
+  const author1 = await User.create({
+    username: 'author1',
+    passwordHash: await bcrypt.hash('password1', 10),
+    role: 'author',
+  });
+
+  const author2 = await User.create({
+    username: 'author2',
+    passwordHash: await bcrypt.hash('password2', 10),
+    role: 'author',
+  });
+
+  const fiction1 = await Fiction.create({
+    title: 'Epic Adventure',
+    description: 'An epic adventure novel.',
+    genre: 'Fantasy',
+    authorId: author1.id,
+  });
+
+  const fiction2 = await Fiction.create({
+    title: 'Sci-fi Saga',
+    description: 'A saga set in space.',
+    genre: 'Sci-fi',
+    authorId: author2.id,
+  });
+
+  const chapter1 = await Chapter.create({
+    title: 'Chapter 1',
+    content: 'Once upon a time...',
+    fictionId: fiction1.id,
+    authorId: author1.id,
+  });
+
+  const chapter2 = await Chapter.create({
+    title: 'Chapter 1',
+    content: 'In a galaxy far far away...',
+    fictionId: fiction2.id,
+    authorId: author2.id,
+  });
+
+  await Comment.create({
+    content: 'Great start!',
+    chapterId: chapter1.id,
+    authorId: author2.id,
+  });
+
+  await Comment.create({
+    content: 'Can\'t wait for more.',
+    chapterId: chapter1.id,
+    authorId: author1.id,
+  });
+
+  console.log('Database seeded successfully');
+  await sequelize.close();
+}
+
+run().catch((err) => {
+  console.error(err);
+  sequelize.close();
+});


### PR DESCRIPTION
## Summary
- add a seed script to populate the database with demo authors, fictions, chapters and comments
- expose `npm run seed` in the backend package.json
- document how to seed sample data

## Testing
- `npm test` in `backend`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68896ca3cb4083218219cb201d8b0e38