### PR TITLE
Add reader role signup option

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -4,13 +4,14 @@ const User = require('../models/user');
 
 exports.signup = async (req, res) => {
   try {
-    const { username, password } = req.body;
+    const { username, password, role } = req.body;
     const passwordHash = await bcrypt.hash(password, 10);
-    // Always create authors. Role cannot be supplied by clients
+    // Default to reader role unless explicitly requesting author
+    const userRole = ['author', 'reader'].includes(role) ? role : 'reader';
     const user = await User.create({
       username,
       passwordHash,
-      role: 'author',
+      role: userRole,
     });
     const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET);
     res.json({ token, id: user.id, username: user.username, role: user.role });

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -14,6 +14,7 @@ const User = sequelize.define('User', {
   role: {
     type: DataTypes.ENUM('reader', 'author'),
     defaultValue: 'reader',
+    allowNull: false,
   },
 });
 

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -25,6 +25,14 @@ describe('Auth endpoints', () => {
     expect(login.status).toBe(200);
     expect(login.body.token).toBeDefined();
   });
+
+  test('signup as reader stores role', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({ username: 'reader1', password: 'pass' });
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe('reader');
+  });
 });
 
 describe('Fiction, chapters and comments', () => {
@@ -35,7 +43,7 @@ describe('Fiction, chapters and comments', () => {
   beforeAll(async () => {
     const res = await request(app)
       .post('/api/auth/signup')
-      .send({ username: 'author1', password: 'pass' });
+      .send({ username: 'author1', password: 'pass', role: 'author' });
     token = res.body.token;
   });
 

--- a/client/src/__tests__/SignupPage.test.jsx
+++ b/client/src/__tests__/SignupPage.test.jsx
@@ -12,10 +12,12 @@ test('submits signup form', async () => {
   render(<SignupPage />);
   fireEvent.change(screen.getByPlaceholderText(/Username/i), { target: { value: 'u' } });
   fireEvent.change(screen.getByPlaceholderText(/Password/i), { target: { value: 'p' } });
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: 'reader' } });
   fireEvent.submit(screen.getByRole('button', { name: /signup/i }).closest('form'));
 
   await waitFor(() => expect(fetch).toHaveBeenCalled());
   const call = fetch.mock.calls[0];
   expect(call[0]).toBe('/api/auth/signup');
   expect(call[1].method).toBe('POST');
+  expect(JSON.parse(call[1].body).role).toBe('reader');
 });

--- a/client/src/components/LoginPage.jsx
+++ b/client/src/components/LoginPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 export default function LoginPage() {
-  const [form, setForm] = useState({ username: '', password: '' });
+  const [form, setForm] = useState({ username: '', password: '', role: 'reader' });
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -22,6 +22,10 @@ export default function LoginPage() {
       <h2>Login</h2>
       <input placeholder="Username" value={form.username} onChange={e => setForm({ ...form, username: e.target.value })} />
       <input type="password" placeholder="Password" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} />
+      <select value={form.role} onChange={e => setForm({ ...form, role: e.target.value })}>
+        <option value="reader">Reader</option>
+        <option value="author">Author</option>
+      </select>
       <button type="submit">Login</button>
     </form>
   );

--- a/client/src/components/SignupPage.jsx
+++ b/client/src/components/SignupPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 export default function SignupPage() {
-  const [form, setForm] = useState({ username: '', password: '' });
+  const [form, setForm] = useState({ username: '', password: '', role: 'reader' });
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -22,6 +22,10 @@ export default function SignupPage() {
       <h2>Signup</h2>
       <input placeholder="Username" value={form.username} onChange={e => setForm({ ...form, username: e.target.value })} />
       <input type="password" placeholder="Password" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} />
+      <select value={form.role} onChange={e => setForm({ ...form, role: e.target.value })}>
+        <option value="reader">Reader</option>
+        <option value="author">Author</option>
+      </select>
       <button type="submit">Signup</button>
     </form>
   );


### PR DESCRIPTION
## Summary
- allow API signup with optional `role` field
- enforce `role` non-null on users
- update tests for new reader role capability
- add role dropdowns on sign up & login pages
- adjust signup page unit test

## Testing
- `npm test` in `backend`
- `npm test` in `client`

------
https://chatgpt.com/codex/tasks/task_e_68897783ac70832191044164c60d6762