### PR TITLE
Add profile page and API endpoints

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,0 +1,20 @@
+const bcrypt = require('bcrypt');
+
+exports.getMe = async (req, res) => {
+  res.json({ id: req.user.id, username: req.user.username, role: req.user.role });
+};
+
+exports.updateMe = async (req, res) => {
+  const { username, password } = req.body;
+  try {
+    if (username) req.user.username = username;
+    if (password) {
+      const hash = await bcrypt.hash(password, 10);
+      req.user.passwordHash = hash;
+    }
+    await req.user.save();
+    res.json({ id: req.user.id, username: req.user.username, role: req.user.role });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const userController = require('../controllers/userController');
+const { authenticate } = require('../middlewares/authMiddleware');
+
+router.get('/me', authenticate, userController.getMe);
+router.put('/me', authenticate, userController.updateMe);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,7 @@ app.use('/api/auth', require('./routes/authRoutes'));
 app.use('/api/fictions', require('./routes/fictionRoutes'));
 app.use('/api/chapters', require('./routes/chapterRoutes'));
 app.use('/api/comments', require('./routes/commentRoutes'));
+app.use('/api/users', require('./routes/userRoutes'));
 
 const PORT = process.env.PORT || 5000;
 

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -33,6 +33,26 @@ describe('Auth endpoints', () => {
     expect(res.status).toBe(200);
     expect(res.body.role).toBe('reader');
   });
+
+  test('profile endpoints return and update user', async () => {
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({ username: 'profile', password: 'pass' });
+    const token = res.body.token;
+
+    const me = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(me.status).toBe(200);
+    expect(me.body.username).toBe('profile');
+
+    const upd = await request(app)
+      .put('/api/users/me')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ username: 'newprofile' });
+    expect(upd.status).toBe(200);
+    expect(upd.body.username).toBe('newprofile');
+  });
 });
 
 describe('Fiction, chapters and comments', () => {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,6 +5,7 @@ import LoginPage from './components/LoginPage';
 import BrowsePage from './components/BrowsePage';
 import FictionPage from './components/FictionPage';
 import AuthorDashboard from './components/AuthorDashboard';
+import ProfilePage from './components/ProfilePage';
 
 const App = () => (
   <Router>
@@ -18,6 +19,7 @@ const App = () => (
         <Link to="/signup">Signup</Link>
         <Link to="/login">Login</Link>
         <Link to="/dashboard">Dashboard</Link>
+        <Link to="/profile">Profile</Link>
       </nav>
     </header>
     <main>
@@ -27,6 +29,7 @@ const App = () => (
         <Route path="/login" element={<LoginPage />} />
         <Route path="/fiction/:id/*" element={<FictionPage />} />
         <Route path="/dashboard" element={<AuthorDashboard />} />
+        <Route path="/profile" element={<ProfilePage />} />
       </Routes>
     </main>
   </Router>

--- a/client/src/__tests__/ProfilePage.test.jsx
+++ b/client/src/__tests__/ProfilePage.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import ProfilePage from '../components/ProfilePage';
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ username: 'u', role: 'reader' }) })
+);
+window.alert = jest.fn();
+
+beforeEach(() => {
+  global.fetch.mockClear();
+  localStorage.setItem('token', 't');
+});
+
+test('loads profile and submits update', async () => {
+  render(<ProfilePage />);
+
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  await screen.findByPlaceholderText('Username');
+
+  fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+
+  fireEvent.change(screen.getByPlaceholderText('Username'), {
+    target: { value: 'new' },
+  });
+  fireEvent.submit(screen.getByText('Update').closest('form'));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  expect(fetch.mock.calls[1][0]).toBe('/api/users/me');
+  expect(fetch.mock.calls[1][1].method).toBe('PUT');
+});

--- a/client/src/components/ProfilePage.jsx
+++ b/client/src/components/ProfilePage.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ProfilePage() {
+  const [user, setUser] = useState(null);
+  const [form, setForm] = useState({ username: '', password: '' });
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    fetch('/api/users/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setUser(data);
+        setForm(f => ({ ...f, username: data.username }));
+      });
+  }, []);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    await fetch('/api/users/me', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(form),
+    });
+    alert('Profile updated');
+  };
+
+  if (!user) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2>Profile</h2>
+      <p>Username: {user.username}</p>
+      <p>Role: {user.role}</p>
+      <form onSubmit={handleSubmit} className="profile-form">
+        <h3>Update Info</h3>
+        <input
+          placeholder="Username"
+          value={form.username}
+          onChange={e => setForm({ ...form, username: e.target.value })}
+        />
+        <input
+          type="password"
+          placeholder="New Password"
+          value={form.password}
+          onChange={e => setForm({ ...form, password: e.target.value })}
+        />
+        <button type="submit">Update</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement user profile API endpoints
- add React profile page with update form
- expose `/api/users` routes on the server
- link profile page in nav and router
- test new backend and frontend behavior

## Testing
- `cd backend && npm test --silent`
- `cd ../client && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68897910b9d88321acf42893f77629ad