### PR TITLE
Implement follow feature

### DIFF
--- a/backend/controllers/followController.js
+++ b/backend/controllers/followController.js
@@ -1,0 +1,24 @@
+const Follow = require('../models/follow');
+const Fiction = require('../models/fiction');
+
+exports.followFiction = async (req, res) => {
+  const { fictionId } = req.params;
+  const [follow] = await Follow.findOrCreate({
+    where: { userId: req.user.id, fictionId },
+  });
+  res.json(follow);
+};
+
+exports.unfollowFiction = async (req, res) => {
+  const { fictionId } = req.params;
+  await Follow.destroy({ where: { userId: req.user.id, fictionId } });
+  res.json({ success: true });
+};
+
+exports.listFollows = async (req, res) => {
+  const follows = await Follow.findAll({
+    where: { userId: req.user.id },
+    include: Fiction,
+  });
+  res.json(follows.map(f => f.Fiction));
+};

--- a/backend/models/follow.js
+++ b/backend/models/follow.js
@@ -1,0 +1,13 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/database');
+const User = require('./user');
+const Fiction = require('./fiction');
+
+const Follow = sequelize.define('Follow', {});
+
+User.hasMany(Follow, { foreignKey: 'userId' });
+Follow.belongsTo(User, { foreignKey: 'userId' });
+Fiction.hasMany(Follow, { foreignKey: 'fictionId' });
+Follow.belongsTo(Fiction, { foreignKey: 'fictionId' });
+
+module.exports = Follow;

--- a/backend/routes/followRoutes.js
+++ b/backend/routes/followRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const followController = require('../controllers/followController');
+const { authenticate } = require('../middlewares/authMiddleware');
+
+router.get('/', authenticate, followController.listFollows);
+router.post('/:fictionId', authenticate, followController.followFiction);
+router.delete('/:fictionId', authenticate, followController.unfollowFiction);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ app.use('/api/fictions', require('./routes/fictionRoutes'));
 app.use('/api/chapters', require('./routes/chapterRoutes'));
 app.use('/api/comments', require('./routes/commentRoutes'));
 app.use('/api/ratings', require('./routes/ratingRoutes'));
+app.use('/api/follows', require('./routes/followRoutes'));
 app.use('/api/users', require('./routes/userRoutes'));
 
 const PORT = process.env.PORT || 5000;

--- a/client/src/__tests__/FictionPage.test.jsx
+++ b/client/src/__tests__/FictionPage.test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import FictionPage from '../components/FictionPage';
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ id: '1' }),
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+  Routes: () => <div />,
+  Route: () => null,
+}));
+
+const fetchMock = jest.fn();
+
+global.fetch = fetchMock;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  localStorage.setItem('token', 'x.eyJpZCI6MX0=.x');
+  fetchMock
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 1, title: 'Fic', description: 'd', authorId: 2 }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ average: 0 }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve([]) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+});
+
+test('follow button calls API', async () => {
+  render(<FictionPage />);
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+
+  fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
+
+  const btn = await screen.findByRole('button', { name: /follow/i });
+  fireEvent.click(btn);
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+  expect(fetchMock.mock.calls[4][0]).toBe('/api/follows/1');
+  expect(fetchMock.mock.calls[4][1].method).toBe('POST');
+});

--- a/client/src/__tests__/ProfilePage.test.jsx
+++ b/client/src/__tests__/ProfilePage.test.jsx
@@ -2,20 +2,21 @@ import React from 'react';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import ProfilePage from '../components/ProfilePage';
 
-global.fetch = jest.fn(() =>
-  Promise.resolve({ json: () => Promise.resolve({ username: 'u', role: 'reader' }) })
-);
+global.fetch = jest.fn();
 window.alert = jest.fn();
 
 beforeEach(() => {
-  global.fetch.mockClear();
+  fetch.mockReset();
+  fetch
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ username: 'u', role: 'reader' }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
   localStorage.setItem('token', 't');
 });
 
 test('loads profile and submits update', async () => {
   render(<ProfilePage />);
 
-  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
   await screen.findByPlaceholderText('Username');
 
   fetch.mockResolvedValueOnce({ json: () => Promise.resolve({}) });
@@ -25,7 +26,7 @@ test('loads profile and submits update', async () => {
   });
   fireEvent.submit(screen.getByText('Update').closest('form'));
 
-  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
-  expect(fetch.mock.calls[1][0]).toBe('/api/users/me');
-  expect(fetch.mock.calls[1][1].method).toBe('PUT');
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(3));
+  expect(fetch.mock.calls[2][0]).toBe('/api/users/me');
+  expect(fetch.mock.calls[2][1].method).toBe('PUT');
 });

--- a/client/src/components/AuthorDashboard.jsx
+++ b/client/src/components/AuthorDashboard.jsx
@@ -5,6 +5,7 @@ export default function AuthorDashboard() {
   const [form, setForm] = useState({ title: '', description: '', genre: '' });
   const [cover, setCover] = useState(null);
   const [fictions, setFictions] = useState([]);
+  const [follows, setFollows] = useState([]);
 
   const userId = (() => {
     const token = localStorage.getItem('token');
@@ -25,6 +26,12 @@ export default function AuthorDashboard() {
           setFictions(data.filter(f => f.authorId === userId));
         }
       });
+    const token = localStorage.getItem('token');
+    if (token) {
+      fetch('/api/follows', { headers: { Authorization: `Bearer ${token}` } })
+        .then(res => res.json())
+        .then(setFollows);
+    }
   }, [userId]);
 
   const handleSubmit = async e => {
@@ -73,6 +80,18 @@ export default function AuthorDashboard() {
           <h3>Your Fictions</h3>
           <ul>
             {fictions.map(f => (
+              <li key={f.id}>
+                <Link to={`/fiction/${f.id}`}>{f.title}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {follows.length > 0 && (
+        <div>
+          <h3>Followed Fictions</h3>
+          <ul>
+            {follows.map(f => (
               <li key={f.id}>
                 <Link to={`/fiction/${f.id}`}>{f.title}</Link>
               </li>

--- a/client/src/components/ProfilePage.jsx
+++ b/client/src/components/ProfilePage.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 export default function ProfilePage() {
   const [user, setUser] = useState(null);
   const [form, setForm] = useState({ username: '', password: '' });
+  const [follows, setFollows] = useState([]);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -15,6 +17,9 @@ export default function ProfilePage() {
         setUser(data);
         setForm(f => ({ ...f, username: data.username }));
       });
+    fetch('/api/follows', { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => res.json())
+      .then(setFollows);
   }, []);
 
   const handleSubmit = async e => {
@@ -38,6 +43,18 @@ export default function ProfilePage() {
       <h2>Profile</h2>
       <p>Username: {user.username}</p>
       <p>Role: {user.role}</p>
+      {follows.length > 0 && (
+        <div>
+          <h3>Followed Fictions</h3>
+          <ul>
+            {follows.map(f => (
+              <li key={f.id}>
+                <Link to={`/fiction/${f.id}`}>{f.title}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <form onSubmit={handleSubmit} className="profile-form">
         <h3>Update Info</h3>
         <input


### PR DESCRIPTION
## Summary
- add Follow model and controller
- provide endpoints for following fictions
- surface follow actions on the Fiction page
- show followed fictions on profile and dashboard
- test follow backend and frontend logic

## Testing
- `cd backend && npm test`
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68897e3c01e483218d2367e70614a881