### PR TITLE
Fix homepage blank rendering and add App test

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,12 +17,12 @@ import AuthorDashboard from './components/AuthorDashboard';
 import ProfilePage from './components/ProfilePage';
 import { AuthContext } from './AuthContext';
 
-const App = () => {
+function AppContent() {
   const { user, logout } = useContext(AuthContext);
   const navigate = useNavigate();
 
   return (
-    <Router>
+    <>
       <header>
         <Link to="/" style={{ display: 'flex', alignItems: 'center' }}>
           <img src="/logo.png" alt="My-Webnovel logo" />
@@ -65,8 +65,14 @@ const App = () => {
           <Route path="/profile" element={<ProfilePage />} />
         </Routes>
       </main>
-    </Router>
+    </>
   );
-};
+}
+
+const App = () => (
+  <Router>
+    <AppContent />
+  </Router>
+);
 
 export default App;

--- a/client/src/__tests__/App.test.jsx
+++ b/client/src/__tests__/App.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from '../App';
+import { AuthContext } from '../AuthContext';
+
+const wrapper = ({ children }) => (
+  <AuthContext.Provider value={{ user: null, logout: jest.fn() }}>
+    {children}
+  </AuthContext.Provider>
+);
+
+test('renders home page', () => {
+  render(<App />, { wrapper });
+  expect(screen.getByText(/welcome to my-webnovel/i)).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- refactor router usage in `App.js` so `useNavigate` is called inside the router
- add regression test ensuring `App` renders the home page

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688990d0da78832199bf3d56f8f970d6