### PR TITLE
Add chapter navigation and stats

### DIFF
--- a/client/src/__tests__/ChapterView.test.jsx
+++ b/client/src/__tests__/ChapterView.test.jsx
@@ -14,8 +14,9 @@ global.fetch = fetchMock;
 beforeEach(() => {
   fetchMock.mockReset();
   fetchMock
-    .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 1, title: 'ch', content: 'txt' }) })
-    .mockResolvedValueOnce({ json: () => Promise.resolve([]) });
+    .mockResolvedValueOnce({ json: () => Promise.resolve({ id: 1, title: 'ch', content: 'txt', createdAt: '2023-01-01', updatedAt: '2023-01-02' }) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve([]) })
+    .mockResolvedValueOnce({ json: () => Promise.resolve([{ id: 1 }]) });
 });
 
 test('loads chapter and posts comment', async () => {
@@ -24,7 +25,7 @@ test('loads chapter and posts comment', async () => {
   );
   render(<ChapterView />, { wrapper });
 
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
 
   fetchMock
     .mockResolvedValueOnce({ json: () => Promise.resolve({}) })
@@ -34,7 +35,7 @@ test('loads chapter and posts comment', async () => {
   fireEvent.change(input, { target: { value: 'hi' } });
   fireEvent.submit(screen.getByText('Comment').closest('form'));
 
-  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
-  expect(fetchMock.mock.calls[2][0]).toContain('/api/comments/1');
-  expect(fetchMock.mock.calls[2][1].method).toBe('POST');
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+  expect(fetchMock.mock.calls[3][0]).toContain('/api/comments/1');
+  expect(fetchMock.mock.calls[3][1].method).toBe('POST');
 });

--- a/client/src/components/ChapterView.jsx
+++ b/client/src/components/ChapterView.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { AuthContext } from '../AuthContext';
 
 export default function ChapterView() {
   const { id, chapterId } = useParams();
   const [chapter, setChapter] = useState(null);
   const [comments, setComments] = useState([]);
+  const [chapters, setChapters] = useState([]);
   const [text, setText] = useState('');
   const { token } = useContext(AuthContext);
 
@@ -16,6 +17,9 @@ export default function ChapterView() {
     fetch(`/api/comments/${chapterId}`)
       .then(res => res.json())
       .then(setComments);
+    fetch(`/api/chapters/${id}`)
+      .then(res => res.json())
+      .then(setChapters);
   }, [id, chapterId]);
 
   const handleComment = async e => {
@@ -35,10 +39,61 @@ export default function ChapterView() {
 
   if (!chapter) return <div>Loading...</div>;
 
+  const chapterIndex = chapters.findIndex(ch => ch.id === Number(chapterId));
+  const prevChapter = chapters[chapterIndex - 1];
+  const nextChapter = chapters[chapterIndex + 1];
+  const wordCount = chapter.content
+    ? chapter.content.trim().split(/\s+/).filter(Boolean).length
+    : 0;
+
+  const NavLink = ({ to, children, disabled }) =>
+    disabled ? (
+      <span className="disabled">{children}</span>
+    ) : (
+      <Link to={to}>{children}</Link>
+    );
+
   return (
     <div>
+      <div className="chapter-nav">
+        <NavLink
+          to={`/fiction/${id}/chapter/${prevChapter ? prevChapter.id : ''}`}
+          disabled={!prevChapter}
+        >
+          Previous Chapter
+        </NavLink>
+        <NavLink
+          to={`/fiction/${id}/chapter/${nextChapter ? nextChapter.id : ''}`}
+          disabled={!nextChapter}
+        >
+          Next Chapter
+        </NavLink>
+      </div>
+
       <h4>{chapter.title}</h4>
+      <div className="chapter-meta">
+        <div>Word Count: {wordCount}</div>
+        <div>First Published: {new Date(chapter.createdAt).toLocaleDateString()}</div>
+        <div>Last Edited: {new Date(chapter.updatedAt).toLocaleDateString()}</div>
+      </div>
+
       <p>{chapter.content}</p>
+
+      <div className="chapter-nav">
+        <NavLink
+          to={`/fiction/${id}/chapter/${prevChapter ? prevChapter.id : ''}`}
+          disabled={!prevChapter}
+        >
+          Previous Chapter
+        </NavLink>
+        <NavLink
+          to={`/fiction/${id}/chapter/${nextChapter ? nextChapter.id : ''}`}
+          disabled={!nextChapter}
+        >
+          Next Chapter
+        </NavLink>
+      </div>
+
       <h5>Comments</h5>
       <ul>
         {comments.map(c => (

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -80,6 +80,34 @@ form {
   margin-bottom: 0.5rem;
 }
 
+.chapter-nav {
+  display: flex;
+  justify-content: space-between;
+  margin: 1rem 0;
+}
+
+.chapter-nav a,
+.chapter-nav span {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  background: #6200ee;
+  color: #fff;
+  text-decoration: none;
+}
+
+.chapter-nav .disabled {
+  background: #ccc;
+  color: #666;
+}
+
+.chapter-meta {
+  border: 1px solid #ddd;
+  background: #f9f9f9;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
 input, textarea, select, button {
   padding: 0.5rem;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- enhance chapter pages with previous/next navigation and metadata
- style navigation and stats
- update ChapterView tests for new API calls

## Testing
- `npm test` in `backend`
- `npm test` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68899adca8bc8321b74ffc6bc917a741