### PR TITLE
Add Markdown support for chapters

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "webnovel-client",
       "version": "1.0.0",
       "dependencies": {
+        "markdown-it": "^14.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.14.1"
@@ -9803,6 +9804,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -9914,6 +9924,41 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9923,6 +9968,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -10706,6 +10757,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -12047,6 +12107,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "markdown-it": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1"
@@ -22,10 +23,10 @@
     "@testing-library/user-event": "^14.4.3",
     "babel-jest": "^29.6.2",
     "babel-loader": "^9.1.3",
+    "css-loader": "^6.8.1",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^30.0.5",
     "style-loader": "^3.3.3",
-    "css-loader": "^6.8.1",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"

--- a/client/src/components/AddChapterPage.jsx
+++ b/client/src/components/AddChapterPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../AuthContext';
+import MarkdownEditor from './MarkdownEditor';
 
 export default function AddChapterPage() {
   const { id } = useParams();
@@ -29,11 +30,11 @@ export default function AddChapterPage() {
         value={form.title}
         onChange={e => setForm({ ...form, title: e.target.value })}
       />
-      <textarea
-        placeholder="Content"
+      <MarkdownEditor
         value={form.content}
-        onChange={e => setForm({ ...form, content: e.target.value })}
+        onChange={value => setForm({ ...form, content: value })}
       />
+      <small>Markdown formatting is supported. Use &gt; for stat block quotes.</small>
       <button type="submit">Create</button>
     </form>
   );

--- a/client/src/components/ChapterView.jsx
+++ b/client/src/components/ChapterView.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
+import MarkdownIt from 'markdown-it';
 import { useParams, Link } from 'react-router-dom';
 import { AuthContext } from '../AuthContext';
 
@@ -9,6 +10,7 @@ export default function ChapterView() {
   const [chapters, setChapters] = useState([]);
   const [text, setText] = useState('');
   const { token } = useContext(AuthContext);
+  const md = new MarkdownIt();
 
   useEffect(() => {
     fetch(`/api/chapters/${id}/${chapterId}`)
@@ -77,7 +79,10 @@ export default function ChapterView() {
         <div>Last Edited: {new Date(chapter.updatedAt).toLocaleDateString()}</div>
       </div>
 
-      <p>{chapter.content}</p>
+      <div
+        className="markdown-content"
+        dangerouslySetInnerHTML={{ __html: md.render(chapter.content || '') }}
+      />
 
       <div className="chapter-nav">
         <NavLink

--- a/client/src/components/FictionPage.jsx
+++ b/client/src/components/FictionPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useContext } from 'react';
 import { useParams, Routes, Route, Link } from 'react-router-dom';
 import { AuthContext } from '../AuthContext';
 import ChapterView from './ChapterView';
+import MarkdownEditor from './MarkdownEditor';
 
 export default function FictionPage() {
   const { id } = useParams();
@@ -135,11 +136,11 @@ export default function FictionPage() {
             value={form.title}
             onChange={e => setForm({ ...form, title: e.target.value })}
           />
-          <textarea
-            placeholder="Content"
+          <MarkdownEditor
             value={form.content}
-            onChange={e => setForm({ ...form, content: e.target.value })}
+            onChange={value => setForm({ ...form, content: value })}
           />
+          <small>Markdown formatting is supported. Use &gt; for stat block quotes.</small>
           <button type="submit">Update</button>
           {editing && (
             <button

--- a/client/src/components/MarkdownEditor.jsx
+++ b/client/src/components/MarkdownEditor.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt();
+
+export default function MarkdownEditor({ value, onChange }) {
+  return (
+    <div className="markdown-editor">
+      <textarea
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="Content (Markdown supported)"
+      />
+      <div
+        className="markdown-preview markdown-content"
+        dangerouslySetInnerHTML={{ __html: md.render(value) }}
+      />
+    </div>
+  );
+}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -125,6 +125,37 @@ button:hover {
   opacity: 0.9;
 }
 
+.markdown-editor {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+}
+
+.markdown-editor textarea {
+  min-height: 200px;
+  width: 100%;
+}
+
+.markdown-preview {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  background: #fff;
+}
+
+.markdown-content blockquote {
+  background: #e8f0ff;
+  border-left: 4px solid #1e88e5;
+  margin: 1rem 0;
+  padding: 0.5rem;
+}
+
+.markdown-content pre {
+  background: #f5f5f5;
+  padding: 0.5rem;
+  overflow-x: auto;
+  border-radius: 4px;
+}
+
 @media (max-width: 600px) {
   header nav {
     width: 100%;


### PR DESCRIPTION
## Summary
- add Markdown editor/preview component
- update add chapter and edit chapter forms to support markdown
- render markdown in chapter view
- style markdown blocks (supports stat block look)
- use markdown-it instead of react-markdown

## Testing
- `cd client && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68899d2f9c24832183c6ad83a1d77996